### PR TITLE
Changing topic to topic ARN (as required)

### DIFF
--- a/src/infraction/index.js
+++ b/src/infraction/index.js
@@ -58,7 +58,7 @@ exports.handler = vandium.api()
 					throw error;
 				}
 
-				validation.Singleton.getInstance().validate(infraction);
+				await validation.Singleton.getInstance().validate(infraction);
 			} else {
 				let error = new Error('Bad Request');
 				error.statusCode = 400;

--- a/src/infraction/validation.js
+++ b/src/infraction/validation.js
@@ -3,17 +3,21 @@
 const common = require('ccc-aws-lambda-common');
 
 // the AWS topic (SNS) that will receive validation requests
-let defaultValidationTopic = process.env.TOPIC_VALIDATION || 'validation_topic';
+let defaultValidationTopic = process.env.ARN_TOPIC_VALIDATION || 'validation_topic';
 
 class Validator {
     constructor(configuration) {
         if (configuration !== undefined) {
             this.sns = configuration.sns;
-            this.validationTopic = configuration.validationTopic;
+            this.validationTopicArn = configuration.validationTopicArn;
         }
 
-        if (!this.validationTopic) {
-            this.validationTopic = defaultValidationTopic;
+        if (!this.validationTopicArn) {
+            this.validationTopicArn = defaultValidationTopic;
+        }
+
+        if (!this.validationTopicArn) {
+            throw new Error('Missing validation topic ARN');
         }
     }
 
@@ -33,7 +37,7 @@ class Validator {
         let sns = await this.client();
         let parameters = {
             Message: JSON.stringify(infraction),
-            TopicArn: this.validationTopic
+            TopicArn: this.validationTopicArn
         }
 
         return new Promise((resolve, reject) => {
@@ -42,6 +46,7 @@ class Validator {
                     console.log(err);
                     reject(err);
                 } else {
+		    console.log('Successful delivery to topic');
                     resolve(undefined);
                 }
             });

--- a/src/infraction/validation.spec.js
+++ b/src/infraction/validation.spec.js
@@ -21,7 +21,8 @@ describe( '...', function() {
 	});
 	let snsInstance = { publish: snsPublish }
 	let validator = new validation.Validator({
-		sns: snsInstance
+		sns: snsInstance,
+		validationTopicArn: 'validation_topic_arn'
 	});
 
 	it('should send to SNS', async function () {
@@ -34,6 +35,6 @@ describe( '...', function() {
 
 		let invocation = snsPublish.mock.calls[0][0];
 		expect(invocation.Message).is.eq(infractionAsJson);
-		expect(invocation.TopicArn).is.eq('validation_topic');
+		expect(invocation.TopicArn).is.eq('validation_topic_arn');
 	});
 });


### PR DESCRIPTION
Minor change, the SNS API requires topicArn not topic.

Discovered and corrected while testing.